### PR TITLE
Added mpMetrics support to Openshift AcmeAir

### DIFF
--- a/manifests-openshift/deploy-acmeair-bookingservice-java.yaml
+++ b/manifests-openshift/deploy-acmeair-bookingservice-java.yaml
@@ -35,6 +35,12 @@ spec:
           value: "http://acmeair-customer-service:9080/customer"
         - name: ACMEAIR_STACKAA_FLIGHT_URL
           value: "http://acmeair-flight-service:9080/flight"
+        - name: JAEGER_AGENT_HOST
+          value: jaeger-all-in-one-inmemory-agent
+        - name: JAEGER_AGENT_PORT
+          value: '6832'
+        - name: JAEGER_ENDPOINT
+          value: 'http://jaeger-all-in-one-inmemory-collector:14268/api/traces'
         readinessProbe:
           httpGet:
             path: /health
@@ -54,7 +60,23 @@ metadata:
   name: acmeair-booking-service
 spec:
   ports:
-    - port: 9080
+    - name: 9080-tcp
+      protocol: TCP
+      port: 9080
+      targetPort: 9080
+  selector:
+    name: acmeair-booking-deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: acmeair-secure-booking-service
+spec:
+  ports:
+    - name: 9443-tcp
+      protocol: TCP
+      port: 9443
+      targetPort: 9443
   selector:
     name: acmeair-booking-deployment
 ---

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -10,7 +10,20 @@
 		httpPort="9080" httpsPort="9443">
   </httpEndpoint>
 
-  <quickStartSecurity userName="${env.USERNAME}" userPassword="${env.PASSWORD}" />
+   <basicRegistry id="basic" realm="WebRealm">
+    <user name="${env.USERNAME}" password="${env.PASSWORD}" />
+  </basicRegistry>
+
+  <administrator-role>
+      <user-access-id>user:WebRealm/${env.USERNAME}</user-access-id>
+  </administrator-role>
+
+  <!-- Basic User Registry not to be used on /booking URL requests -->
+  <authFilter id="mpJwtAuthFilter">
+    <requestUrl id="request" urlPattern="/booking" matchType="notContain" />
+  </authFilter>
+
+  <mpJwt id="jwtUserConsumer" authFilterRef="mpJwtAuthFilter" ignoreApplicationAuthMethod="false" mapToUserRegistry="true" />
 
   <webApplication name="acmeair-bookingservice" location="acmeair-bookingservice-java-3.3.war" contextRoot="/booking">
     <classloader apiTypeVisibility="api,ibm-api,spec,stable,third-party"/>

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -8,9 +8,13 @@
   <!-- To access this server from a remote client add a host attribute to the following element, e.g. host="*" -->
   <httpEndpoint id="defaultHttpEndpoint" host="*"
 		httpPort="9080" httpsPort="9443">
+    <accessLogging
+      filepath="${server.output.dir}/logs/http_defaultEndpoint_access.log"
+      logFormat='%h %u %t "%r" %s %b %D %{User-agent}i'>
+    </accessLogging>
   </httpEndpoint>
 
-   <basicRegistry id="basic" realm="WebRealm">
+  <basicRegistry id="basic" realm="WebRealm">
     <user name="${env.USERNAME}" password="${env.PASSWORD}" />
   </basicRegistry>
 
@@ -24,6 +28,8 @@
   </authFilter>
 
   <mpJwt id="jwtUserConsumer" authFilterRef="mpJwtAuthFilter" ignoreApplicationAuthMethod="false" mapToUserRegistry="true" />
+  
+  <logging consoleFormat="json" consoleSource="message,trace,accessLog,ffdc,audit" messageFormat="json" messageSource="message,trace,accessLog,ffdc,audit" traceSpecification="com.acmeair*=all" />
 
   <webApplication name="acmeair-bookingservice" location="acmeair-bookingservice-java-3.3.war" contextRoot="/booking">
     <classloader apiTypeVisibility="api,ibm-api,spec,stable,third-party"/>


### PR DESCRIPTION
* Disabled mpJwt on non-application endpoints to allow basic authentication with mpMetrics on `/metrics`
* Added extra 9443 service for use by mpMetrics
* Added Jaeger environment variables
* Enabled JSON logging 